### PR TITLE
[cli-property] added listing properties for a group #81

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: node_js
 node_js:
   - 7.0
 script:
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash npm test; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm test; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: node_js
 node_js:
   - 7.0
-script:
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm test; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
   - 7.0
-script: npm test
+script:
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash npm test; fi'

--- a/bin/akamaiProperty
+++ b/bin/akamaiProperty
@@ -210,6 +210,17 @@ function searchProperties(app, searchString, options) {
     })
 }
 
+function listProperties(app, group, contract, toFile) {
+    if(toFile){
+        return app.listPropertiesToFile(group, contract, toFile)
+    }else{
+        return app.listProperties(group, contract)
+        .then(data => {
+            console.log(JSON.stringify(data,'',2))
+        })
+    }    
+}
+
 function retrieveFormats(app, options) {
     return app.retrieveFormats()
     .then(data => {
@@ -335,6 +346,27 @@ function main () {
             }
           }
 
+      })
+      .command('list', {
+        desc: 'list properties in a group',
+        setup: sywac => {
+            sywac
+                .string('--contract <contract>', {
+                    desc: 'Contract to list properties from',
+                    group: 'Location options:'
+                })
+                .string('--group <group>', {
+                    desc: 'Group to list properties from',
+                    group: 'Location options:'
+                })
+                .file('--file <path>', {
+                    desc: 'Output file'
+                })
+        },
+        run: options => {
+            let app = new WebSite({path:options.config, section: options.section, debug: options.debug});
+            return listProperties(app, options.group, options.contract, options.file)
+        }
       })
       .command('search <property>', { 
         desc: 'search for a property name',

--- a/src/website.js
+++ b/src/website.js
@@ -415,6 +415,32 @@ class WebSite {
         })
     }
 
+    _listProperties(groupId, contractId){
+        return new Promise((resolve, reject) => {
+            if(!groupId && !contractId){
+                reject("Please specify a Group and a Contract");
+            }else if(!groupId){
+                reject("Please specify a Group")
+            }else if(!contractId){
+                reject("Please specify a Contract")
+            }
+            console.error('... retrieving list of Properties for this group and contract');
+            let request = {
+                method: 'GET',
+                path: `/papi/v1/properties?contractId=${contractId}&groupId=${groupId}`
+            }
+            this._edge.auth(request);
+            this._edge.send(function(data, response) {
+                if (response && response.statusCode >= 200 && response.statusCode < 400) {
+                    let parsed = JSON.parse(response.body);
+                    resolve(parsed);
+                } else {
+                    reject(response);
+                }
+            })
+        })
+    }
+
     _getPropertyMetadata(propertyId, groupId, contractId) {
          return new Promise((resolve, reject) => {
             console.error('... getting info for ' + propertyId);
@@ -1457,6 +1483,27 @@ class WebSite {
             .then(result => {
                 return result;
             })
+    }
+
+    listProperties(groupId, contractId) {
+        return this._listProperties(groupId, contractId)
+        .then(result => {
+            return result;
+        })
+    }
+
+    listPropertiesToFile(groupId, contractId, toFile) {
+        return this._listProperties(groupId, contractId)
+        .then(result => {
+            return new Promise((resolve, reject) => {
+                fs.writeFile(untildify(toFile), JSON.stringify(result, '', 2), (err) => {
+                    if (err)
+                        reject(err);
+                    else
+                        resolve(result);
+                });
+            });
+        })
     }
 
     retrieveGroups() {

--- a/src/website.js
+++ b/src/website.js
@@ -418,11 +418,14 @@ class WebSite {
     _listProperties(groupId, contractId){
         return new Promise((resolve, reject) => {
             if(!groupId && !contractId){
-                reject("Please specify a Group and a Contract");
+                console.error("Please specify a Group and a Contract");
+                reject(null);
             }else if(!groupId){
-                reject("Please specify a Group")
+                console.error("Please specify a Group");
+                reject(null);
             }else if(!contractId){
-                reject("Please specify a Contract")
+                console.error("Please specify a Contract");
+                reject(null);
             }
             console.error('... retrieving list of Properties for this group and contract');
             let request = {
@@ -434,6 +437,9 @@ class WebSite {
                 if (response && response.statusCode >= 200 && response.statusCode < 400) {
                     let parsed = JSON.parse(response.body);
                     resolve(parsed);
+                } else if(response.statusCode === 403){
+                    console.error('... your client credentials have no access to this group, skipping {%s : %s}', contractId, groupId);
+                    reject(null);
                 } else {
                     reject(response);
                 }


### PR DESCRIPTION
@synedra PR from a fork now,
- added error handling for when not authorized to selected group/contract.
- the debug output [Object object] is still happening for when status code is not success nor 403( same as for all the other endpoints). it's related to #82 and I believe Guille's fix is going to fix that as what is missing is a catch block and that's part of what guille implemented. I'm going to follow this scenario and see why guilles PR travis build failed. this "debug output [Object object]" is an issue on all endpoints so I feel like this issue can be closed and track this issue separately.

I closed the other PR from a branch