### PR TITLE
Add exception to update a property to 'latest' rules format

### DIFF
--- a/src/website.js
+++ b/src/website.js
@@ -815,7 +815,13 @@ class WebSite {
                                 body: rules,
                                 headers: {'Content-Type':'application/vnd.akamai.papirules.' + rules.ruleFormat + '+json'}
                         }
-                    } else {
+                    } else if (rules.ruleFormat && rules.ruleFormat == "latest" ) {
+                        request = {
+                                method: 'PUT',
+                                path: `/papi/v1/properties/${propertyId}/versions/${version}/rules?contractId=${contractId}&groupId=${groupId}`,
+                                body: rules,
+                                headers: {'Content-Type':'application/vnd.akamai.papirules.latest.json'}
+                     } else {
                         request = {
                                 method: 'PUT',
                                 path: `/papi/v1/properties/${propertyId}/versions/${version}/rules?contractId=${contractId}&groupId=${groupId}`,


### PR DESCRIPTION
When updating a configuration to the 'latest' rule format, the content-type sent needs to be application/vnd.akamai.papirules.latest+json.
