### PR TITLE
Enable account switch key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/bin/akamaiProperty
+++ b/bin/akamaiProperty
@@ -154,7 +154,7 @@ function updateProperty(app, targetProperty, options) {
     if (options.file)
         return app.updateFromFile( targetProperty, 
                                         options.file, 
-                                        options.origin);
+                                        options.notes);
     
     if (options.srcprop)
         return app.copy(   options.srcprop, 

--- a/bin/akamaiProperty
+++ b/bin/akamaiProperty
@@ -395,7 +395,7 @@ function main () {
         desc: 'retrieve account groups',
         run: (options, context) => {
           try {
-            let app = new WebSite({path: options.config, section: options.section, debug: options.debug});
+            let app = new WebSite({path: options.config, section: options.section, debug: options.debug, key: options["account-key"]});
             return retrieveGroups(app)
           } catch (error) {
             return errorMessage(error, context);
@@ -406,7 +406,7 @@ function main () {
         desc: 'get rules formats',
         run: (options, context) => {
           try {
-            let app = new WebSite({path: options.config, section: options.section, debug: options.debug});
+            let app = new WebSite({path: options.config, section: options.section, debug: options.debug, key: options["account-key"]});
             if (options.newest) {
               return retrieveNewestFormat(app);
             } else {
@@ -427,7 +427,7 @@ function main () {
                 })
         },
         run: options => {
-            let app = new WebSite({path:options.config, section: options.section, debug: options.debug});
+            let app = new WebSite({path:options.config, section: options.section, debug: options.debug, key: options["account-key"]});
             return listProducts(app, options)
         }
       })
@@ -450,7 +450,7 @@ function main () {
                 })
         },
         run: options => {
-            let app = new WebSite({path:options.config, section: options.section, debug: options.debug});
+            let app = new WebSite({path:options.config, section: options.section, debug: options.debug, key: options["account-key"]});
             return listProperties(app, options.group, options.contract, options.file)
         }
       })
@@ -460,7 +460,7 @@ function main () {
         paramsDesc: 'Enter a string to search for.',
         run: (options, context) => {
           try {
-            let app = new WebSite({path: options.config, section: options.section, debug: options.debug});
+            let app = new WebSite({path: options.config, section: options.section, debug: options.debug, key: options["account-key"]});
             return searchProperties(app, options.string)
           } catch (error) {
             return errorMessage(error, context);
@@ -539,7 +539,7 @@ function main () {
             if(!flagsAreValid(context, options)){
               return;
             }
-            let app = new WebSite({path: options.config, section: options.section, debug: options.debug});
+            let app = new WebSite({path: options.config, section: options.section, debug: options.debug, key: options["account-key"]});
             return createProperty(app, options.property, options).then(() => {
               if (options.forward || options.variables || options.notes) {
                 return modifyProperty(app, options.property, options, 'create')
@@ -613,7 +613,7 @@ function main () {
         },
         run: (options, context) => {
             try {
-              let app = new WebSite({path: options.config, section: options.section, debug: options.debug});
+              let app = new WebSite({path: options.config, section: options.section, debug: options.debug, key: options["account-key"]});
               return modifyProperty(app, options.property, options)
             } catch (error) {
               return errorMessage(error, context);
@@ -643,7 +643,7 @@ function main () {
         },
         run: (options, context) => {
           try {
-            let app = new WebSite({path: options.config, section: options.section, debug: options.debug});
+            let app = new WebSite({path: options.config, section: options.section, debug: options.debug, key: options["account-key"]});
             return activateProperty(app, options.property, options)
           } catch (error) {
             return errorMessage(error, context);
@@ -669,7 +669,7 @@ function main () {
         },
         run: (options, context) => {
           try {
-            let app = new WebSite({path: options.config, section: options.section, debug: options.debug});
+            let app = new WebSite({path: options.config, section: options.section, debug: options.debug, key: options["account-key"]});
             return deactivateProperty(app, options.property, options)
           } catch (error){
             return errorMessage(error, context);
@@ -681,7 +681,7 @@ function main () {
         run: (options, context) => {
           try {
             options.network = "BOTH"
-            let app = new WebSite({path: options.config, section: options.section, debug: options.debug});
+            let app = new WebSite({path: options.config, section: options.section, debug: options.debug, key: options["account-key"]});
             return deactivateProperty(app, options.property, options).then(() => {
               return deleteProperty(app, options.property, options)
             })
@@ -711,7 +711,7 @@ function main () {
               console.log("Required: srcprop or file")
               return Promise.resolve();
             }
-            let app = new WebSite({path: options.config, section: options.section, debug: options.debug});
+            let app = new WebSite({path: options.config, section: options.section, debug: options.debug, key: options["account-key"]});
             return updateProperty(app, options.property, options);
           } catch (error) {
             return errorMessage(error, context);
@@ -731,7 +731,7 @@ function main () {
         })},
         run: (options, context) => {
           try {
-            let app = new WebSite({path: options.config, section: options.section, debug: options.debug});
+            let app = new WebSite({path: options.config, section: options.section, debug: options.debug, key: options["account-key"]});
             if (options.hostnames) {
               return retrieveHostnames(app, options.property)
             } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3013,7 +3013,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3031,11 +3032,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3048,15 +3051,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3159,7 +3165,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3169,6 +3176,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3181,17 +3189,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3208,6 +3219,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3280,7 +3292,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3290,6 +3303,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3365,7 +3379,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3395,6 +3410,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3412,6 +3428,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3450,11 +3467,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/src/website.js
+++ b/src/website.js
@@ -72,7 +72,8 @@ class WebSite {
         this._propertyHostnameList = {};
         this._edgeHostnames = [];
         this._newestRulesFormat = "";
-        this._accountSwitchKey = "";
+        this._accountSwitchKey = auth.key;
+        console.info('Account Key set to: ' + this._accountSwitchKey)
         if (auth.create) {
             this._initComplete = true;
         }
@@ -1422,7 +1423,7 @@ class WebSite {
      * @returns {Promise} the {object} of Property as the {TResult}
      */
     lookupPropertyIdFromHost(hostname, env = LATEST_VERSION.PRODUCTION, accountKey) {
-        this._accountSwitchKey = accountKey;
+        // // this._accountSwitchKey = accountKey;
         return this._getProperty(hostname, env);
     }
 
@@ -1516,7 +1517,7 @@ class WebSite {
     
     searchProperties(searchString, accountKey) {
         let searchObj = {"propertyName" : searchString};
-        this._accountSwitchKey = accountKey;
+        // // this._accountSwitchKey = accountKey;
         return this._searchByValue(searchObj)
             .then(result => {
                 return result;
@@ -1524,7 +1525,7 @@ class WebSite {
     }
 
     listProperties(groupId, contractId, accountKey) {
-        this._accountSwitchKey = accountKey;
+        // // this._accountSwitchKey = accountKey;
         return this._listProperties(groupId, contractId)
         .then(result => {
             return result;
@@ -1532,7 +1533,7 @@ class WebSite {
     }
 
     listPropertiesToFile(groupId, contractId, toFile, accountKey) {
-        this._accountSwitchKey = accountKey;
+        // // this._accountSwitchKey = accountKey;
         return this._listProperties(groupId, contractId)
         .then(result => {
             return new Promise((resolve, reject) => {
@@ -1547,7 +1548,7 @@ class WebSite {
     }
 
     retrieveGroups(accountKey) {
-        this._accountSwitchKey = accountKey;
+        // // this._accountSwitchKey = accountKey;
         return this._getGroupList()
             .then(result => {
                return Promise.resolve(result.groups.items)
@@ -1556,7 +1557,7 @@ class WebSite {
 
     retrieveFormats(latest=false, accountKey) {
         let latestRule;
-        this._accountSwitchKey = accountKey;
+        // // this._accountSwitchKey = accountKey;
         return this._retrieveFormats()
             .then(result => {
                 if (!latest) {
@@ -1586,7 +1587,7 @@ class WebSite {
          */
     retrieve(propertyLookup, versionLookup = LATEST_VERSION.LATEST, hostnames=false, accountKey) {
         let propertyId;
-        this._accountSwitchKey = accountKey;
+        // // this._accountSwitchKey = accountKey;
         return this._getProperty(propertyLookup)
             .then(property => {
                 if (!hostnames) {
@@ -1611,7 +1612,7 @@ class WebSite {
    */
 
     retrieveToFile(propertyLookup, toFile, versionLookup = LATEST_VERSION.LATEST, accountKey) {
-        this._accountSwitchKey = accountKey;
+        // this._accountSwitchKey = accountKey;
         return this.retrieve(propertyLookup, versionLookup, false, this._accountSwitchKey)
             .then(data => {
                 console.error(`Writing ${propertyLookup} rules to ${toFile}`);
@@ -1636,7 +1637,7 @@ class WebSite {
      */
 
     retrievePropertyRuleFormat(propertyLookup, versionLookup = LATEST_VERSION.LATEST, accountKey) {
-        this._accountSwitchKey = accountKey;
+        // this._accountSwitchKey = accountKey;
         return this.retrieve(propertyLookup, versionLookup, false, this._accountSwitchKey)
             .then(data => {
                 console.log(JSON.stringify(data.ruleFormat));
@@ -1645,7 +1646,7 @@ class WebSite {
     }
 
     createNewPropertyVersion(propertyLookup, accountKey) {
-        this._accountSwitchKey = accountKey;
+        // this._accountSwitchKey = accountKey;
         return this._getProperty(propertyLookup)
             .then(property => {
                 let propertyName = property.propertyName;
@@ -1696,7 +1697,7 @@ class WebSite {
      * @returns {Promise} returns a promise with the updated form of the
      */
     updateFromFile(propertyLookup, srcFile, comment = false, accountKey) {
-        this._accountSwitchKey = accountKey;
+        // this._accountSwitchKey = accountKey;
         return new Promise((resolve, reject) => {
             fs.readFile(untildify(srcFile), (err, data) => {
                 if (err) {
@@ -1724,7 +1725,7 @@ class WebSite {
      * @returns {Promise} returns a promise with the TResult of boolean
      */
     copy(fromProperty, fromVersion = LATEST_VERSION.LATEST, toProperty, comment = false, accountKey) {
-        this._accountSwitchKey = accountKey;
+        // this._accountSwitchKey = accountKey;
         return this.retrieve(fromProperty, fromVersion, false, this._accountSwitchKey)
             .then(fromRules => {
                 console.error(`Copy ${fromProperty} v${fromRules.propertyVersion} to ${toProperty}`);
@@ -1778,7 +1779,7 @@ class WebSite {
             emailNotification = [email];
         let activationVersion = version;
         let property = propertyLookup;
-        this._accountSwitchKey = accountKey;
+        // this._accountSwitchKey = accountKey;
 
         return this._getProperty(propertyLookup)
             .then(data => {
@@ -1817,7 +1818,7 @@ class WebSite {
         if (!Array.isArray(email))
             email = [email];
         let property;
-        this._accountSwitchKey = accountKey;
+        // this._accountSwitchKey = accountKey;
 
         return this._getProperty(propertyLookup)
             .then(data => {
@@ -1847,7 +1848,7 @@ class WebSite {
             propertyId,
             configName;
 
-        this._accountSwitchKey = accountKey;
+        // this._accountSwitchKey = accountKey;
 
         return this._getProperty(propertyLookup)
             .then(data => {
@@ -1878,7 +1879,7 @@ class WebSite {
      *     If the host name is moving between property configurations, use lookupPropertyIdFromHost()
      */
     deleteProperty(propertyLookup, accountkey) {
-      this._accountSwitchKey = accountkey;
+      // this._accountSwitchKey = accountKey;
         //TODO: deactivate first
         return this._getProperty(propertyLookup)
             .then(property => {
@@ -1894,7 +1895,7 @@ class WebSite {
      *     If the host name is moving between property configurations, use lookupPropertyIdFromHost()
      */
     moveProperty(propertyLookup, destGroup, accountKey) {
-        this._accountSwitchKey = accountKey;
+        // this._accountSwitchKey = accountKey;
         //TODO: deactivate first
         console.error(`Moving ${propertyLookup} to ` + destGroup);
 
@@ -1902,7 +1903,7 @@ class WebSite {
     }
 
     setRuleFormat(propertyLookup, version, ruleformat, accountKey) {
-        this._accountSwitchKey = accountKey;
+        // this._accountSwitchKey = accountKey;
         
         return this._getProperty(propertyLookup)
             .then(data => {
@@ -1916,7 +1917,7 @@ class WebSite {
     }
 
     setCpcode(propertyLookup, version, cpcode, accountKey) {
-        this._accountSwitchKey = accountKey;
+        // this._accountSwitchKey = accountKey;
         return this._getProperty(propertyLookup)
             .then(data => {
                 version = WebSite._getLatestVersion(data, version)
@@ -1948,7 +1949,7 @@ class WebSite {
             propertyId,
             configName;
 
-        this._accountSwitchKey = accountKey;
+        // this._accountSwitchKey = accountKey;
 
         let names = this._getConfigAndHostname(propertyLookup, hostnames);
         configName = names[0];
@@ -1984,7 +1985,7 @@ class WebSite {
             configName,
             hostlist;
 
-        this._accountSwitchKey = accountKey;
+        // this._accountSwitchKey = accountKey;
             
         let names = this._getConfigAndHostname(propertyLookup, hostnames);
         configName = names[0];
@@ -2038,7 +2039,7 @@ class WebSite {
         };
         let variables;
 
-        this._accountSwitchKey = accountKey;
+        // this._accountSwitchKey = accountKey;
 
         return new Promise((resolve, reject) => {
             fs.readFile(untildify(variablefile), (err, data) => {
@@ -2111,7 +2112,7 @@ class WebSite {
     }
 
     getVariables(propertyLookup, versionLookup=0, filename=null, accountKey) {
-        this._accountSwitchKey = accountKey;       
+        // this._accountSwitchKey = accountKey;       
         return this._getProperty(propertyLookup)
             .then(property => {
                     let version = (versionLookup && versionLookup > 0) ? versionLookup : WebSite._getLatestVersion(property, versionLookup)
@@ -2136,7 +2137,7 @@ class WebSite {
     }
 
     setComments(propertyLookup, version = 0, comment, accountKey) {
-        this._accountSwitchKey = accountKey;
+        // this._accountSwitchKey = accountKey;
         console.error("... adding version notes")
         return this._getProperty(propertyLookup)
             .then(property => {
@@ -2156,7 +2157,7 @@ class WebSite {
         let forwardHostHeader;
         let customForward = "";
 
-        this._accountSwitchKey = accountKey;
+        // this._accountSwitchKey = accountKey;
         
         if (forward == "origin") {
             forwardHostHeader = "ORIGIN_HOSTNAME"
@@ -2198,7 +2199,7 @@ class WebSite {
     }
 
     setSureRoute(propertyLookup, version=0, sureroutemap, surerouteto, sureroutetohost, accountKey) {
-        this._accountSwitchKey = accountKey;
+        // this._accountSwitchKey = accountKey;
         return this._getProperty(propertyLookup)
             .then(property => {
                 version = WebSite._getLatestVersion(property, version);
@@ -2266,7 +2267,7 @@ class WebSite {
                             accountKey,
                             newcpcodename = null) {
 
-        this._accountSwitchKey = accountKey;
+        // this._accountSwitchKey = accountKey;
 
         let newEdgeHostname;
         if (!configName && !hostnames) {
@@ -2400,7 +2401,7 @@ class WebSite {
         let names = this._getConfigAndHostname(configName, hostnames);
         configName = names[0];
         hostnames = names[1];
-        this._accountSwitchKey = accountKey;
+        // this._accountSwitchKey = accountKey;
         return new Promise((resolve, reject) => {
             fs.readFile(untildify(srcFile), (err, data) => {
                 if (err)


### PR DESCRIPTION
Updated the <code>WebSite</code> class to initialize the <code>_accountSwitchKey</code> variable as part of the constructor, and included the <code>account-key</code> option when the object was initialized in the <code>akamaiProperty</code> file.