### PR TITLE
Fix issue where modify --new command not creating new version based o…

### DIFF
--- a/bin/akamaiProperty
+++ b/bin/akamaiProperty
@@ -309,7 +309,7 @@ function retrieveHostnames(app, targetProperty, version , accountKey) {
 function modifyProperty(app, targetProperty, options, command) {
     let version = numberVersion(options.propver) ? numberVersion(options.propver) : 0;
     if (options.new) {
-            return app.createNewPropertyVersion(targetProperty, options["account-key"])
+            return app.createNewPropertyVersion(targetProperty, options["account-key"], version);
         }
     if (options.addhosts && options.addhosts.length > 0) {
             return app.addHostnames(targetProperty, version, options.addhosts, options.edgehostname, options["account-key"]);

--- a/src/website.js
+++ b/src/website.js
@@ -1640,13 +1640,13 @@ class WebSite {
             });
     }
 
-    createNewPropertyVersion(propertyLookup, accountKey) {
+    createNewPropertyVersion(propertyLookup, accountKey, fromVersion) {
         this._accountSwitchKey = accountKey;
         return this._getProperty(propertyLookup)
             .then(property => {
                 let propertyName = property.propertyName;
                 console.error(`Creating new version for ${propertyName}`);
-                const version = WebSite._getLatestVersion(property, 0);
+                const version = fromVersion ? fromVersion : WebSite._getLatestVersion(property, 0);
                 property.latestVersion += 1;
                 return this._copyPropertyVersion(property, version);
         })


### PR DESCRIPTION
Fix an issue where "modify --new" command not creating new version based on --propver argument

**Test case:**
run: akamai property modify <property_name> --new --propver <version number the new property based on>

**Expected behavior:**
the output of the above command should contain:
... copy property (<property_name>) v<version number in the --propver arg>
The resulting new version should be based on the version specified in the --propver argument

**Before the fix:**
akamai property modify ritamnandi --new --propver 50
... searching propertyName for ritamnandi
... getting info for prp_xxxxxx
Creating new version for ritamnandi
**... copy property (ritamnandi) v55**
Command time: 0.13 mins
//New version was created from v55 which was the latest version and not from the version specified.

**After the fix:**
akamai property modify ritamnandi --new --propver 50
... searching propertyName for ritamnandi
... getting info for prp_xxxxxx
Creating new version for ritamnandi
... copy property (ritamnandi) v50
Command time: 0.12 mins
//New version was created from v50

