### PR TITLE
Allows `createFromExisting()` to work between groupIds.

### DIFF
--- a/src/website.js
+++ b/src/website.js
@@ -2474,7 +2474,7 @@ class WebSite {
                 } else {
                     newEdgeHostname = 1;
                 }
-                return this._getEHNId(data.propertyId, data.version, groupId, contractId)
+                return this._getEHNId(data.propertyId, data.version, data.groupId, data.contractId)
             })
                
             .then(clone_ehn =>{


### PR DESCRIPTION
Hello and thank you for an awesome cli/library!

We encountered a small bug when using this as a library to clone an existing property from one group from another. 
   
This change makes the query for hostnames use the source groupId instead of the target one when querying for source hostnames. Without this fix the process failes when sending in a `groupId` different from the source one.

Kind regards,
David and the platform team on BonnierNews