### PR TITLE
Fix an issue where "create" command with "--newcpcodename" arg throw TypeError: Cannot read property 'behaviors' of undefined.

### DIFF
--- a/src/website.js
+++ b/src/website.js
@@ -1365,7 +1365,7 @@ class WebSite {
         return ([configName, hostnames])
     }
 
-    _setRules(groupId, contractId, productId, configName, cpcode = null, hostnames = [], origin = null, secure = false, baserules=null, newcpcodename = false) {
+    _setRules(groupId, contractId, productId, configName, cpcode = null, hostnames = [], origin = null, secure = false, newcpcodename = false, baserules=null) {
 
         return new Promise((resolve, reject) => {
             if (cpcode && !newcpcodename) {


### PR DESCRIPTION
Fix an issue where "create" command with "--newcpcodename" arg throw TypeError: Cannot read property 'behaviors' of undefined.
**Full stacktrace**
TypeError: Cannot read property 'behaviors' of undefined
    at Promise (/Users/username/.akamai-cli/src/cli-property/src/website.js:753:25)
    at new Promise (<anonymous>)
    at WebSite._updatePropertyBehaviors (/Users/username/.akamai-cli/src/cli-property/src/website.js:748:16)
    at Promise.then.then.rules (/Users/username/.akamai-cli/src/cli-property/src/website.js:1388:29)
    at process._tickCallback (internal/process/next_tick.js:68:7)

**Steps to reproduce:**
run: akamai property create <new_property_name> --clone <existing_property_name_to_clone> --srcver <version_to_clone> --nocopy <whether_to_copy> --hostnames <hostname_for_the_property> --origin <origin_hostname_or_IP> --edgehostname <akamai_edgehostname_assign_to_hostname> --newcpcodename <name_of_cpcode_assign_to_property>

**Expected behavior:**
it should produce a new property with the settings specified and cpcode with the name specified in --newcpcodename

**Actual behavior**
CLI execution produce error :
TypeError: Cannot read property 'behaviors' of undefined
    at Promise (/Users/username/.akamai-cli/src/cli-property/src/website.js:753:25)
    at new Promise (<anonymous>)
    at WebSite._updatePropertyBehaviors (/Users/username/.akamai-cli/src/cli-property/src/website.js:748:16)
    at Promise.then.then.rules (/Users/username/.akamai-cli/src/cli-property/src/website.js:1388:29)
    at process._tickCallback (internal/process/next_tick.js:68:7)



**Before the fix:**
$akamai property create rnandi3 --clone ritamnandi --srcver 1 --nocopy yes --hostnames rn12.test.com --origin 14.14.14.14 --edgehostname rnandi.edgekey.net --newcpcodename rnisbest
... searching propertyName for ritamnandi
... getting info for prp_xxxxxx
... retrieving clone info
... retrieving clone rules for cpcode
Creating property config rnandi3

ERROR:
Cannot read property 'behaviors' of undefined

TypeError: Cannot read property 'behaviors' of undefined
at Promise (C:\Users\esenopra.akamai-cli\src\cli-property\src\website.js:753:25)
at new Promise (<anonymous>)
at WebSite._updatePropertyBehaviors (C:\Users\esenopra.akamai-cli\src\cli-property\src\website.js:748:16)
at Promise.then.then.rules (C:\Users\esenopra.akamai-cli\src\cli-property\src\website.js:1388:29)
at process._tickCallback (internal/process/next_tick.js:68:7)

**After the fix:**
$akamai property create rnandi3 --clone ritamnandi --srcver 1 --nocopy yes --hostnames rn12.test.com --origin 14.14.14.14 --edgehostname rnandi.edgekey.net --newcpcodename rnisbest
... searching propertyName for ritamnandi
... getting info for prp_484872
... retrieving clone info
... retrieving clone rules for cpcode
Creating property config rnandi3
Creating new CPCode for property
Retrieving rnandi3 v1
... retrieving property (rnandi3) v1
... updating property (rnandi3) v1
... retrieving list of hostnames {ctr_xxxxx : grp_xxxxx : prp_xxxxx}
Updating property hostnames
Adding hostname rn12.test.com
Command time: 0.33 mins